### PR TITLE
Detect the WeChat App built-in browser

### DIFF
--- a/src/BrowserDetection.php
+++ b/src/BrowserDetection.php
@@ -1137,7 +1137,8 @@ class BrowserDetection
 			$browser_list[] = array('Opera Coast', 'Coast/', '/Coast\/([0-9]+)/', '1', '');
 			$browser_list[] = array('Android Browser', '/Android.*Version\/[.0-9]+\s(?:Mobile\s)?Safari(|\/[.0-9]+\sCyanogenMod.*)+$/', '/Android.*Version\/([0-9]+\.[0-9]+)/', '1', 'Chrome/');
 			$browser_list[] = array('Playstation Browser', '/(PlayStation\s|PLAYSTATION\s)/', '/(PlayStation\s|PLAYSTATION\s)/', '1', '');
-			
+			$browser_list[] = array('WeChat App', 'MicroMessenger/', '/MicroMessenger\/([0-9]+\.[0-9]+\.[0-9]+)/', '1', '');
+
 			foreach($browser_list as $browser_list_va)
 			{
 				$match = $browser_list_va[1];


### PR DESCRIPTION
Sample UA: 'Mozilla/5.0 (iPhone; CPU iPhone OS 15_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 MicroMessenger/8.0.22(0x18001626) NetType/WIFI Language/zh_CN'